### PR TITLE
Fix settings access in address manager initialization

### DIFF
--- a/src/scm_cicd/address.py
+++ b/src/scm_cicd/address.py
@@ -69,12 +69,24 @@ class SCMAddressManager:
             return
 
         try:
+            # Get credentials from settings module
+            client_id = settings.get("client_id", "")
+            client_secret = settings.get("client_secret", "")
+            tsg_id = settings.get("tsg_id", "")
+
+            # Check if credentials are available
+            if not all([client_id, client_secret, tsg_id]):
+                logger.error("Missing required credentials. Please set them in .secrets.yaml or environment variables.")
+                sys.exit(1)
+
             # Initialize the client with credentials from settings
             self.client = Scm(
-                client_id=settings.client_id,
-                client_secret=settings.client_secret,
-                tsg_id=settings.tsg_id,
-                log_level=settings.log_level,
+                client_id=client_id,
+                client_secret=client_secret,
+                tsg_id=tsg_id,
+                api_base_url=settings.get("api_base_url", "https://api.strata.paloaltonetworks.com"),
+                token_url=settings.get("token_url", "https://auth.apps.paloaltonetworks.com/am/oauth2/access_token"),
+                log_level=settings.get("log_level", "INFO"),
             )
             logger.info("SCM client initialized successfully")
         except AuthenticationError as e:


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved error handling for missing credentials

- Updated client initialization with flexible settings

- Added validation for required credentials

- Enhanced logging and error messages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>address.py</strong><dd><code>Improve address manager initialization and error handling</code></dd></summary>
<hr>

src/scm_cicd/address.py

<li>Added credential retrieval from settings with fallback<br> <li> Implemented validation for required credentials<br> <li> Updated SCM client initialization with flexible parameters<br> <li> Enhanced error handling and logging


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cicd/pull/11/files#diff-39d6b4f305ef5a7d6df2376fe32deb49daa9413226c1b47fdefc96fff63ed341">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>