### PR TITLE
Fix settings access in both managers to properly use Dynaconf's pattern

### DIFF
--- a/src/scm_cicd/address.py
+++ b/src/scm_cicd/address.py
@@ -69,26 +69,31 @@ class SCMAddressManager:
             return
 
         try:
-            # Get credentials from settings module
-            client_id = settings.get("client_id", "")
-            client_secret = settings.get("client_secret", "")
-            tsg_id = settings.get("tsg_id", "")
+            # Get credentials from environment variables or settings
+            # Dynaconf will automatically look for SCM_CLIENT_ID, SCM_CLIENT_SECRET, etc.
+            client_id = settings.CLIENT_ID
+            client_secret = settings.CLIENT_SECRET
+            tsg_id = settings.TSG_ID
 
-            # Check if credentials are available
-            if not all([client_id, client_secret, tsg_id]):
-                logger.error("Missing required credentials. Please set them in .secrets.yaml or environment variables.")
-                sys.exit(1)
+            # These may not be set, so provide defaults
+            api_base_url = getattr(settings, "API_BASE_URL", "https://api.strata.paloaltonetworks.com")
+            token_url = getattr(settings, "TOKEN_URL", "https://auth.apps.paloaltonetworks.com/am/oauth2/access_token")
+            log_level = getattr(settings, "LOG_LEVEL", "INFO")
 
-            # Initialize the client with credentials from settings
+            # Initialize the client with credentials
             self.client = Scm(
                 client_id=client_id,
                 client_secret=client_secret,
                 tsg_id=tsg_id,
-                api_base_url=settings.get("api_base_url", "https://api.strata.paloaltonetworks.com"),
-                token_url=settings.get("token_url", "https://auth.apps.paloaltonetworks.com/am/oauth2/access_token"),
-                log_level=settings.get("log_level", "INFO"),
+                api_base_url=api_base_url,
+                token_url=token_url,
+                log_level=log_level,
             )
             logger.info("SCM client initialized successfully")
+        except AttributeError as e:
+            logger.error(f"Missing required credentials: {e}")
+            logger.error("Please set SCM_CLIENT_ID, SCM_CLIENT_SECRET, and SCM_TSG_ID environment variables")
+            sys.exit(1)
         except AuthenticationError as e:
             logger.error(f"Authentication failed: {e}")
             sys.exit(1)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved settings access using Dynaconf's pattern

- Enhanced error handling for missing credentials

- Added default values for optional settings

- Standardized client initialization across files


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>address.py</strong><dd><code>Refactor SCM client initialization in address module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/scm_cicd/address.py

<li>Updated settings access to use Dynaconf's pattern<br> <li> Added default values for optional settings<br> <li> Improved error handling for missing credentials<br> <li> Standardized client initialization process


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cicd/pull/12/files#diff-39d6b4f305ef5a7d6df2376fe32deb49daa9413226c1b47fdefc96fff63ed341">+19/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security_rules.py</strong><dd><code>Refactor SCM client initialization in security rules module</code></dd></summary>
<hr>

src/scm_cicd/security_rules.py

<li>Updated settings access to use Dynaconf's pattern<br> <li> Added default values for optional settings<br> <li> Improved error handling for missing credentials<br> <li> Standardized client initialization process


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cicd/pull/12/files#diff-aa72c07ff8a6278e3eaca9343c047204c9a4f50dc989c02b365c24b042b5c998">+27/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>